### PR TITLE
Implement Audiences (& feature classes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ use Optimizely
 ...
 
 $variant = Optimizely::activate(new Experiment(auth()->user()));
+$variant = Experiment::activate(auth()->user());
 ---- OR
 $isFeatureEnabled = Optimizely::isFeatureEnabled(new Experiment(auth()->user());
 $isFeatureEnabled = Experiment::isEnabled(auth()->user());

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ use Optimizely
 
 ...
 
-$variant = Optimizely::activate($experimentName, Auth::user()->getRouteKey(), $params);
+$variant = Optimizely::activate(new Experiment(auth()->user()));
 ---- OR
-$isFeatureEnabled = Optimizely::isFeatureEnabled($experimentName, Auth::user()->getRouteKey(), $params);
-
+$isFeatureEnabled = Optimizely::isFeatureEnabled(new Experiment(auth()->user());
+$isFeatureEnabled = Experiment::isEnabled(auth()->user());
 ```

--- a/src/Contracts/AudienceContract.php
+++ b/src/Contracts/AudienceContract.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace TemperWorks\LaravelOptimizely\Contracts;
+
+
+interface AudienceContract
+{
+    public function __construct(FeatureContract $feature);
+
+    public function getAttributes();
+}

--- a/src/Contracts/AudienceContract.php
+++ b/src/Contracts/AudienceContract.php
@@ -5,7 +5,5 @@ namespace TemperWorks\LaravelOptimizely\Contracts;
 
 interface AudienceContract
 {
-    public function __construct(FeatureContract $feature);
-
-    public function getAttributes();
+    public function getAttributes() : array;
 }

--- a/src/Contracts/FeatureContract.php
+++ b/src/Contracts/FeatureContract.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TemperWorks\LaravelOptimizely\Contracts;
+
+interface FeatureContract
+{
+    public function getExperiment() : string;
+
+    public function getIdentifier() : string;
+
+    public function getAttributes() : array;
+
+    public function getAudiences() : array;
+
+    public function getParams() : array;
+}

--- a/src/Features/AbstractFeature.php
+++ b/src/Features/AbstractFeature.php
@@ -8,7 +8,7 @@ use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
 
 abstract class AbstractFeature implements FeatureContract
 {
-    public function getParams() : array
+    final public function getParams() : array
     {
         $params = $this->getAttributes();
         $audiences = collect($this->getAudiences())
@@ -37,5 +37,10 @@ abstract class AbstractFeature implements FeatureContract
     public static function isEnabled()
     {
         return app()->make('laravel-optimizely')->isFeatureEnabled(new static(...func_get_args()));
+    }
+
+    public static function activate()
+    {
+        return app()->make('laravel-optimizely')->activate(new static(...func_get_args()));
     }
 }

--- a/src/Features/AbstractFeature.php
+++ b/src/Features/AbstractFeature.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace  TemperWorks\LaravelOptimizely\Features;
+
+
+use TemperWorks\LaravelOptimizely\OptimizelyWrapper;
+
+abstract class AbstractFeature
+{
+    public function getParams() : array
+    {
+        $params = $this->getAttributes();
+        $audiences = collect($this->getAudiences())->map(function ($audience) {
+            return (new $audience($this))->getAttributes();
+        });
+
+
+        return $audiences->collapse()->merge($params)->toArray();
+    }
+
+    public function getAttributes() : array
+    {
+        return [
+            //
+        ];
+    }
+
+    public function getAudiences() : array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function isEnabled()
+    {
+        return app()->make(OptimizelyWrapper::class)->isFeatureEnabled(new static(...func_get_args()));
+    }
+}

--- a/src/Features/AbstractFeature.php
+++ b/src/Features/AbstractFeature.php
@@ -3,16 +3,19 @@
 namespace  TemperWorks\LaravelOptimizely\Features;
 
 
+use TemperWorks\LaravelOptimizely\Contracts\AudienceContract;
+use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
 use TemperWorks\LaravelOptimizely\OptimizelyWrapper;
 
-abstract class AbstractFeature
+abstract class AbstractFeature implements FeatureContract
 {
     public function getParams() : array
     {
         $params = $this->getAttributes();
-        $audiences = collect($this->getAudiences())->map(function ($audience) {
-            return (new $audience($this))->getAttributes();
-        });
+        $audiences = collect($this->getAudiences())
+            ->map(function (AudienceContract $audience) {
+                return $audience->getAttributes();
+            });
 
 
         return $audiences->collapse()->merge($params)->toArray();

--- a/src/Features/AbstractFeature.php
+++ b/src/Features/AbstractFeature.php
@@ -31,7 +31,7 @@ abstract class AbstractFeature implements FeatureContract
     public function getAudiences() : array
     {
         return [
-            //
+            // new TestAudience(),
         ];
     }
 

--- a/src/Features/AbstractFeature.php
+++ b/src/Features/AbstractFeature.php
@@ -5,7 +5,6 @@ namespace  TemperWorks\LaravelOptimizely\Features;
 
 use TemperWorks\LaravelOptimizely\Contracts\AudienceContract;
 use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
-use TemperWorks\LaravelOptimizely\OptimizelyWrapper;
 
 abstract class AbstractFeature implements FeatureContract
 {
@@ -37,6 +36,6 @@ abstract class AbstractFeature implements FeatureContract
 
     public static function isEnabled()
     {
-        return app()->make(OptimizelyWrapper::class)->isFeatureEnabled(new static(...func_get_args()));
+        return app()->make('laravel-optimizely')->isFeatureEnabled(new static(...func_get_args()));
     }
 }

--- a/src/LaravelOptimizelyServiceProvider.php
+++ b/src/LaravelOptimizelyServiceProvider.php
@@ -12,7 +12,7 @@ class LaravelOptimizelyServiceProvider extends \Illuminate\Support\ServiceProvid
         $this->loadRoutesFrom(__DIR__.'/routes.php');
 
         $this->app->bind('laravel-optimizely', function(){
-            return app()->make(OptimizelyWrapper::class, [app()->make(Datafile::class)]);
+            return app()->make(OptimizelyWrapper::class);
         });
 
         $this->app->bind(Optimizely::class, function() {

--- a/src/OptimizelyWrapper.php
+++ b/src/OptimizelyWrapper.php
@@ -2,6 +2,7 @@
 
 use Cache;
 use Optimizely\Optimizely;
+use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
 
 class OptimizelyWrapper
 {
@@ -11,14 +12,22 @@ class OptimizelyWrapper
     private $datafile;
     private $optimizely;
 
-    public function isFeatureEnabled(string $experiment, string $userID, $params = []) : bool
+    public function isFeatureEnabled(FeatureContract $feature) : bool
     {
-        return $this->cacheOptimizelyResponse($experiment, $userID, $params, self::TYPE_IS_FEATURE_ENABLED) ?? false;
+        return $this->cacheOptimizelyResponse(
+            $feature->getExperiment(), 
+            $feature->getIdentifier(), 
+            $feature->getParams(), 
+            self::TYPE_IS_FEATURE_ENABLED) ?? false;
     }
 
-    public function activate(string $experiment, string $userID, $params = []) : ?string
+    public function activate(FeatureContract $feature) : ?string
     {
-        return $this->cacheOptimizelyResponse($experiment, $userID, $params, self::TYPE_ACTIVATE);
+        return $this->cacheOptimizelyResponse(
+            $feature->getExperiment(), 
+            $feature->getIdentifier(), 
+            $feature->getParams(), 
+            self::TYPE_ACTIVATE);
     }
 
     public function track($event, $userID, $params = [])

--- a/src/Tests/Experiments/FeatureTest.php
+++ b/src/Tests/Experiments/FeatureTest.php
@@ -46,4 +46,14 @@ class FeatureTest extends \BrowserKitTest
 
         TestFeature::isEnabled(2);
     }
+
+    public function test_activate_should_call_optimizely()
+    {
+        $mock = \Mockery::mock(OptimizelyWrapper::class);
+        $mock->shouldReceive('activate')->with(\Hamcrest\Core\IsEqual::equalTo(new TestFeature(2)));
+
+        $this->app->instance(OptimizelyWrapper::class, $mock);
+
+        TestFeature::activate(2);
+    }
 }

--- a/src/Tests/Experiments/FeatureTest.php
+++ b/src/Tests/Experiments/FeatureTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TemperWorks\LaravelOptimizely\Tests\Experiments;
+
+use TemperWorks\LaravelOptimizely\OptimizelyWrapper;
+use TemperWorks\LaravelOptimizely\Tests\Stubs\TestAudience;
+use TemperWorks\LaravelOptimizely\Tests\Stubs\TestFeature;
+
+class FeatureTest extends \BrowserKitTest
+{
+
+    public function test_it_passes_correct_data()
+    {
+        $feature = new TestFeature(2);
+
+        $this->assertEquals('text_experiment', $feature->getExperiment());
+        $this->assertEquals(2, $feature->getIdentifier());
+        $this->assertEquals([TestAudience::class], $feature->getAudiences());
+        $this->assertEquals(['foo' => 'bar'], $feature->getAttributes());
+    }
+
+    public function test_it_merges_data_correctly()
+    {
+        $feature = new TestFeature(1);
+
+        $this->assertEquals([
+            'is_odd' => true,
+            'foo' => 'bar',
+        ], $feature->getParams());
+
+        $feature = new TestFeature(2);
+
+        $this->assertEquals([
+            'is_odd' => true,
+            'foo' => 'bar',
+        ], $feature->getParams());
+    }
+
+    public function test_isEnabled_should_call_optimizely()
+    {
+        $mock = \Mockery::mock(OptimizelyWrapper::class);
+        $mock->shouldReceive('isFeatureEnabled')->with(
+            new TestFeature(2)
+        );
+
+        $this->app->instance(OptimizelyWrapper::class, $mock);
+
+        TestFeature::isEnabled(2);
+    }
+}

--- a/src/Tests/Experiments/FeatureTest.php
+++ b/src/Tests/Experiments/FeatureTest.php
@@ -13,7 +13,7 @@ class FeatureTest extends \BrowserKitTest
     {
         $feature = new TestFeature(2);
 
-        $this->assertEquals('text_experiment', $feature->getExperiment());
+        $this->assertEquals('test_experiment', $feature->getExperiment());
         $this->assertEquals(2, $feature->getIdentifier());
         $this->assertEquals([TestAudience::class], $feature->getAudiences());
         $this->assertEquals(['foo' => 'bar'], $feature->getAttributes());
@@ -24,14 +24,14 @@ class FeatureTest extends \BrowserKitTest
         $feature = new TestFeature(1);
 
         $this->assertEquals([
-            'is_odd' => true,
+            'is_even' => false,
             'foo' => 'bar',
         ], $feature->getParams());
 
         $feature = new TestFeature(2);
 
         $this->assertEquals([
-            'is_odd' => true,
+            'is_even' => true,
             'foo' => 'bar',
         ], $feature->getParams());
     }
@@ -39,9 +39,7 @@ class FeatureTest extends \BrowserKitTest
     public function test_isEnabled_should_call_optimizely()
     {
         $mock = \Mockery::mock(OptimizelyWrapper::class);
-        $mock->shouldReceive('isFeatureEnabled')->with(
-            new TestFeature(2)
-        );
+        $mock->shouldReceive('isFeatureEnabled')->with(\Hamcrest\Core\IsEqual::equalTo(new TestFeature(2)));
 
         $this->app->instance(OptimizelyWrapper::class, $mock);
 

--- a/src/Tests/Experiments/FeatureTest.php
+++ b/src/Tests/Experiments/FeatureTest.php
@@ -15,7 +15,8 @@ class FeatureTest extends \BrowserKitTest
 
         $this->assertEquals('test_experiment', $feature->getExperiment());
         $this->assertEquals(2, $feature->getIdentifier());
-        $this->assertEquals([TestAudience::class], $feature->getAudiences());
+        $this->assertIsArray($feature->getAudiences());
+        $this->assertInstanceOf(TestAudience::class, $feature->getAudiences()[0]);
         $this->assertEquals(['foo' => 'bar'], $feature->getAttributes());
     }
 

--- a/src/Tests/OptimizelyWrapper.php
+++ b/src/Tests/OptimizelyWrapper.php
@@ -5,6 +5,7 @@ use Mockery;
 use Optimizely\Optimizely;
 use TemperWorks\LaravelOptimizely\Datafile;
 use TemperWorks\LaravelOptimizely\OptimizelyWrapper;
+use TemperWorks\LaravelOptimizely\Tests\Stubs\TestFeature;
 
 class OptimizelyWrapperTest extends \BrowserKitTest
 {
@@ -21,7 +22,7 @@ class OptimizelyWrapperTest extends \BrowserKitTest
         Cache::shouldReceive("has")->andReturn(false);
         Cache::shouldReceive("forever");
 
-        $this->app->make(OptimizelyWrapper::class)->isFeatureEnabled("experiment", "aaaaa");
+        $this->app->make(OptimizelyWrapper::class)->isFeatureEnabled(new TestFeature(123));
     }
 
     public function test_isFeatureEnabled_doesnt_call_optimizely_twice()
@@ -37,6 +38,6 @@ class OptimizelyWrapperTest extends \BrowserKitTest
         Cache::shouldReceive("has")->once()->andReturn(true);
         Cache::shouldReceive("get")->once()->andReturn(true);
 
-        $this->app->make(OptimizelyWrapper::class)->isFeatureEnabled("experiment", "aaaaa");
+        $this->app->make(OptimizelyWrapper::class)->isFeatureEnabled(new TestFeature(123));
     }
 }

--- a/src/Tests/Stubs/TestAudience.php
+++ b/src/Tests/Stubs/TestAudience.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TemperWorks\LaravelOptimizely\Tests\Stubs
+
+use TemperWorks\LaravelOptimizely\Contracts\AudienceContract;
+use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
+
+class TestAudience implements AudienceContract{
+
+    protected $feature;
+
+    public function __construct(FeatureContract  $feature)
+    {
+        $this->feature = $feature;
+    }
+
+    public function getAttributes()
+    {
+        return [
+            'is_odd' => $this->feature->getIdentifier() % 2 === 0
+        ];
+    }
+}

--- a/src/Tests/Stubs/TestAudience.php
+++ b/src/Tests/Stubs/TestAudience.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TemperWorks\LaravelOptimizely\Tests\Stubs
+namespace TemperWorks\LaravelOptimizely\Tests\Stubs;
 
 use TemperWorks\LaravelOptimizely\Contracts\AudienceContract;
 use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
@@ -17,7 +17,7 @@ class TestAudience implements AudienceContract{
     public function getAttributes()
     {
         return [
-            'is_odd' => $this->feature->getIdentifier() % 2 === 0
+            'is_even' => $this->feature->getIdentifier() % 2 === 0
         ];
     }
 }

--- a/src/Tests/Stubs/TestAudience.php
+++ b/src/Tests/Stubs/TestAudience.php
@@ -3,21 +3,20 @@
 namespace TemperWorks\LaravelOptimizely\Tests\Stubs;
 
 use TemperWorks\LaravelOptimizely\Contracts\AudienceContract;
-use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
 
 class TestAudience implements AudienceContract{
 
-    protected $feature;
+    protected $id;
 
-    public function __construct(FeatureContract  $feature)
+    public function __construct(int $id)
     {
-        $this->feature = $feature;
+        $this->id = $id;
     }
 
-    public function getAttributes()
+    public function getAttributes() : array
     {
         return [
-            'is_even' => $this->feature->getIdentifier() % 2 === 0
+            'is_even' => $this->id % 2 === 0
         ];
     }
 }

--- a/src/Tests/Stubs/TestFeature.php
+++ b/src/Tests/Stubs/TestFeature.php
@@ -30,4 +30,11 @@ class TestFeature extends AbstractFeature implements FeatureContract {
             'foo' => 'bar'
         ];
     }
+
+    public function getAudiences() : array
+    {
+        return [
+            TestAudience::class
+        ];
+    }
 }

--- a/src/Tests/Stubs/TestFeature.php
+++ b/src/Tests/Stubs/TestFeature.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace TemperWorks\LaravelOptimizely\Tests\Stubs;
+
+use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
+use TemperWorks\LaravelOptimizely\Features\AbstractFeature;
+
+class TestFeature extends AbstractFeature implements FeatureContract {
+
+    public $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getExperiment() : string
+    {
+        return 'test_experiment';
+    }
+
+    public function getIdentifier() : string
+    {
+        return $this->id;
+    }
+
+    public function getAttributes() : array
+    {
+        return [
+            'foo' => 'bar'
+        ];
+    }
+}

--- a/src/Tests/Stubs/TestFeature.php
+++ b/src/Tests/Stubs/TestFeature.php
@@ -2,10 +2,9 @@
 
 namespace TemperWorks\LaravelOptimizely\Tests\Stubs;
 
-use TemperWorks\LaravelOptimizely\Contracts\FeatureContract;
 use TemperWorks\LaravelOptimizely\Features\AbstractFeature;
 
-class TestFeature extends AbstractFeature implements FeatureContract {
+class TestFeature extends AbstractFeature {
 
     public $id;
 
@@ -21,7 +20,7 @@ class TestFeature extends AbstractFeature implements FeatureContract {
 
     public function getIdentifier() : string
     {
-        return $this->id;
+        return (string) $this->id;
     }
 
     public function getAttributes() : array
@@ -34,7 +33,7 @@ class TestFeature extends AbstractFeature implements FeatureContract {
     public function getAudiences() : array
     {
         return [
-            TestAudience::class
+            new TestAudience($this->id)
         ];
     }
 }


### PR DESCRIPTION
This PR revises the way of calling the isFeatureEnabled.
Instead of passing a few params you may pass a class, this class holds all the required data.
The benefit of this is that we have 1 place where we can see all features and change them easily.
On top of that it allows us to create audiences and easily pass them to an experiment.